### PR TITLE
Add HTML viewer for USGS USMIN data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # USMin
+
+This repository contains a simple web page for viewing mining-related data from the USGS USMIN database.
+
+## Usage
+
+1. Open `index.html` in a modern web browser.
+2. The page loads sample data for Alaska directly from the USGS site. To view another state or your own dataset, update the `loadShapefile` call in the script with a different URL or local file path.
+
+## Data sources
+
+Data is hosted by the [USGS](https://mrdata.usgs.gov/usmin/). You can download individual state shapefiles or the full geodatabase from links on that site.
+
+## Notes
+
+Loading the entire dataset in the browser may be resource intensive. For best performance, load data for a single state or convert the geodatabase to a tiled or simplified format.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>USGS USMIN Visualization</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <style>
+        html, body, #map { height: 100%; margin: 0; }
+    </style>
+</head>
+<body>
+    <div id="map"></div>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/shpjs@3.4.1/dist/shp.min.js"></script>
+    <script>
+        const map = L.map('map').setView([45, -95], 4);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 18,
+            attribution: '&copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors'
+        }).addTo(map);
+
+        function loadShapefile(url) {
+            fetch(url)
+                .then(res => res.arrayBuffer())
+                .then(buf => shp(buf))
+                .then(geojson => {
+                    L.geoJSON(geojson, {
+                        pointToLayer: (feature, latlng) => L.circleMarker(latlng, {radius:3}),
+                        onEachFeature: (feature, layer) => {
+                            const props = feature.properties || {};
+                            const name = props.NAME || props.name || '';
+                            if (name) layer.bindPopup(name);
+                        }
+                    }).addTo(map);
+                })
+                .catch(err => console.error('Error loading', err));
+        }
+
+        // Example: load Alaska data. Change the URL to load other states or your own file
+        loadShapefile('https://mrdata.usgs.gov/usmin/state/usmin-AK.zip');
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Leaflet-based `index.html` for viewing USMIN data
- expand README with usage instructions and data source links

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688bbe60ad1c832b8c4576abef063cef